### PR TITLE
wayland: Fix allocation of touchpoints

### DIFF
--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -774,7 +774,7 @@ int _glfwPlatformInit(void)
 
     _glfwInitTimerPOSIX();
 
-    _glfw.wl.touchpoints = calloc(4, sizeof(_GLFWtouchpointWayland*));
+    _glfw.wl.touchpoints = calloc(4, sizeof(_GLFWtouchpointWayland));
     _glfw.wl.touchpointsSize = 4;
 
     for (i = 0; i < _glfw.wl.touchpointsSize; ++i)


### PR DESCRIPTION
Use the size of the _GLFWtouchpointWayland structure, not the size of a
pointer when allocation touchpoints.

Signed-off-by: Sjoerd Simons sjoerd.simons@collabora.co.uk
